### PR TITLE
Removed unneeded and errorneous line.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,5 @@
 body {
     font-family: Arial, Helvetica, sans-serif;
-    background-image: #dddddd
 }
 
 p, span {


### PR DESCRIPTION
Hi Mira. Your CSS file has this one unneeded declaration (it wasn't being used). It should've been `background-color`, not `background-image`. 

But since your site is just going for white background, we can just remove the line altogether.